### PR TITLE
Update french translation (rings) for 1.9.5

### DIFF
--- a/5E_spellcasting/lib/semi_spont/fr_FR/semi_spont.tra
+++ b/5E_spellcasting/lib/semi_spont/fr_FR/semi_spont.tra
@@ -54,7 +54,7 @@ On raconte que jadis, un grand magicien amnien défia les pouvoirs magiques de M
 PARAMÈTRES :
 
 Capacités d'équipement :
-– Une fois par jour, permet de rafraîchir tous les sorts profanes de niveau 1
+– Une fois par jour, double les sorts profanes de niveau 1
 
 Poids : 0~
 @611 = ~Anneau de sorcellerie de Kontik~
@@ -64,7 +64,7 @@ Kontik, puissante magicienne au service d'Aurile, a pris cet anneau à un ennemi
 PARAMÈTRES :
 
 Capacités d'équipement :
-– Une fois par jour, permet de rafraîchir tous les sorts profanes de niveaux 1 et 2
+– Une fois par jour, double les sorts profanes de niveaux 1 et 2
 
 Capacités de combat :
 - tous les dégâts de froid infligés par le porteur sont augmentés de 15%
@@ -79,7 +79,7 @@ Ce puissant anneau appartenait récemment à Édion, nécromancien mourant natif
 PARAMÈTRES :
 
 Capacités d'équipement :
-– Une fois par jour, permet de rafraîchir tous les sorts profanes de niveau 5
+– Une fois par jour, double les sorts profanes de niveau 5
 
 Poids : 0~
 //


### PR DESCRIPTION
Updates french translation for the descriptions of spell cast slot doubling rings to follow 1.9.5 changes